### PR TITLE
Update alt text and product names

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,28 +26,28 @@
         <div class="shirts-container">
           <img
             src="assets/1Product.png"
-            alt="Preview of Ratphex-T shirt"
+            alt="AI-generated Jon Osmond wearing the white T-shirt"
             class="shirt top-left"
             data-mouse-src="assets/1Model.png"
-            data-shirt-name="Ratphex-T"
+            data-shirt-name="white T-shirt"
             data-model-size="L"
           />
-          <img src="assets/1Model.png" alt="AI-generated Jon Osmond wearing a shirt" class="rat-center" id="centerImage" />
+          <img src="assets/1Model.png" alt="AI-generated Jon Osmond wearing the white T-shirt" class="rat-center" id="centerImage" />
           <span id="info-tooltip" data-tooltip='This is not Jon Osmond'>?</span>
           <img
             src="assets/3Product.png"
-            alt="Preview of AnimalCollective-T shirt"
+            alt="AI-generated Jon Osmond wearing the metal T-shirt"
             class="shirt bottom-left"
             data-mouse-src="assets/3Model.png"
-            data-shirt-name="AnimalCollective-T"
+            data-shirt-name="metal T-shirt"
             data-model-size="S"
           />
           <img
             src="assets/2Product.png"
-            alt="Preview of RatwardScissor-T shirt"
+            alt="AI-generated Jon Osmond wearing the MN Wild jersey"
             class="shirt middle-right"
             data-mouse-src="assets/2Model.png"
-            data-shirt-name="RatwardScissor-T"
+            data-shirt-name="MN Wild jersey"
             data-model-size="XL"
           />
         </div>

--- a/index.js
+++ b/index.js
@@ -349,7 +349,13 @@ document.addEventListener('DOMContentLoaded', () => {
           centerImage.src = newImageSrc;
           originalCenterImageSrc = newImageSrc;
         }
-        // const shirtName = activeShirt.getAttribute('data-shirt-name'); // Potentially for future use.
+
+        // Update the alt text so screen readers reflect the current shirt.
+        const shirtName = activeShirt.getAttribute('data-shirt-name');
+        if (shirtName) {
+          centerImage.alt = `AI-generated Jon Osmond wearing the ${shirtName}`;
+        }
+
         updateTooltip(); // Update tooltip based on the new model/shirt.
 
         // Reset the dragged shirt's position back to its initial spot.


### PR DESCRIPTION
## Summary
- clarify alt text for product images as white T-shirt, MN Wild jersey, and metal T-shirt
- sync dynamic alt text with new shirt names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a41974d148324802730896d1212cc