### PR TITLE
Add drop shadows to model images

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -284,6 +284,7 @@ a {
     -moz-user-select: none;
     -ms-user-select: none;
     -webkit-user-drag: none;
+    filter: drop-shadow(15px 15px 20px rgba(0,0,0,0.4));
 }
 
 .shirt {
@@ -293,6 +294,7 @@ a {
     transition: transform 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55);
     transform-origin: center center;
     will-change: transform;
+    filter: drop-shadow(5px 5px 10px rgba(0,0,0,0.2));
 }
 
 .shirt.grabbed {
@@ -402,6 +404,7 @@ a {
         top: 45%;
         left: 50%;
         /* transform: translate(-50%, -50%); is inherited */
+        filter: drop-shadow(15px 15px 20px rgba(0,0,0,0.4));
     }
 
     #info-tooltip { 


### PR DESCRIPTION
## Summary
- add default drop shadow to `.rat-center` so central model looks sunlit
- give `.shirt` images a subtle drop shadow
- apply the same shadow in the responsive `.rat-center` rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a4d3649608324b956fde7d9294b72