### PR TITLE
Reduce drop-shadow spread

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -287,7 +287,7 @@ a {
     -moz-user-select: none;
     -ms-user-select: none;
     -webkit-user-drag: none;
-    filter: drop-shadow(15px 15px 20px rgba(0,0,0,0.4));
+    filter: drop-shadow(8px 8px 12px rgba(0,0,0,0.15));
 }
 
 .shirt {
@@ -297,12 +297,12 @@ a {
     transition: transform 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55);
     transform-origin: center center;
     will-change: transform;
-    filter: drop-shadow(5px 5px 10px rgba(0,0,0,0.2));
+    filter: drop-shadow(3px 3px 6px rgba(0,0,0,0.08));
 }
 
 .shirt.grabbed {
     transform: scale(1.05);
-    filter: drop-shadow(0 5px 10px rgba(0,0,0,0.15));
+    filter: drop-shadow(0 3px 6px rgba(0,0,0,0.05));
 }
 
 .shirt.dragging-right {
@@ -311,7 +311,7 @@ a {
               rotateX(5deg)
               scale(0.92, 0.98) 
               skew(-5deg, 2deg);
-    filter: drop-shadow(5px 5px 15px rgba(0,0,0,0.2));
+    filter: drop-shadow(3px 3px 8px rgba(0,0,0,0.08));
 }
 
 .shirt.dragging-left {
@@ -320,7 +320,7 @@ a {
               rotateX(5deg)
               scale(0.92, 0.98) 
               skew(5deg, -2deg);
-    filter: drop-shadow(-5px 5px 15px rgba(0,0,0,0.2));
+    filter: drop-shadow(-3px 3px 8px rgba(0,0,0,0.08));
 }
 
 .top-left { top: 20%; left: 15%; }
@@ -407,7 +407,7 @@ a {
         top: 45%;
         left: 50%;
         /* transform: translate(-50%, -50%); is inherited */
-        filter: drop-shadow(15px 15px 20px rgba(0,0,0,0.4));
+        filter: drop-shadow(8px 8px 12px rgba(0,0,0,0.15));
     }
 
     #info-tooltip { 


### PR DESCRIPTION
## Summary
- dial down shadow blur and offsets on shirt states
- soften central image shadow in all views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a528539a48324b2f9eaa4143d0b73