### PR TITLE
Implement mobile improvements

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -5,7 +5,7 @@
 }
 
 :root {
-  font-size: 12px;
+  font-size: clamp(12px, 2.5vw, 16px);
 
   /* Cheerful, subtle gradient background */
   --color-text: #f2f2f2;      /* light text for contrast */
@@ -293,11 +293,12 @@ a {
 
 .shirt {
     position: absolute;
-    max-width: 9.8%;
+    max-width: clamp(9.8%, 12vw, 21%);
     height: auto;
     transition: transform 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55);
     transform-origin: center center;
     will-change: transform;
+    touch-action: none;
 
     filter: drop-shadow(2px 2px 4px rgba(0,0,0,0.08));
 

--- a/index.html
+++ b/index.html
@@ -40,8 +40,9 @@
             data-mouse-src="assets/white-tshirt-model.png"
             data-shirt-name="white T-shirt"
             data-model-size="L"
+            loading="lazy"
           />
-          <img src="assets/white-tshirt-model.png" alt="AI-generated Jon Osmond wearing the white T-shirt" class="rat-center" id="centerImage" />
+          <img src="assets/white-tshirt-model.png" alt="AI-generated Jon Osmond wearing the white T-shirt" class="rat-center" id="centerImage" loading="eager" />
           <span id="info-tooltip" data-tooltip='This is not Jon Osmond'>?</span>
           <img
             src="assets/metal-tshirt-product.png"
@@ -50,6 +51,7 @@
             data-mouse-src="assets/metal-tshirt-model.png"
             data-shirt-name="metal T-shirt"
             data-model-size="S"
+            loading="lazy"
           />
           <img
             src="assets/mn-wild-jersey-product.png"
@@ -58,6 +60,7 @@
             data-mouse-src="assets/mn-wild-jersey-model.png"
             data-shirt-name="MN Wild jersey"
             data-model-size="XL"
+            loading="lazy"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- scale base font size with `clamp`
- lazily load shirt images and set pointer events
- disable scrolling while dragging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a590d10f083249712407f12ce97bd