### PR TITLE
Add gardening shirt support

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -339,6 +339,7 @@ a {
 .top-left { top: 20%; left: 15%; }
 .middle-right { top: 45%; left: 80%; }
 .bottom-left { top: 70%; left: 15%; }
+.bottom-right { top: 70%; left: 80%; }
 
 
 /* Tooltip for Model Info */
@@ -414,6 +415,7 @@ a {
     .top-left { top: 25%; left: 5%; }
     .middle-right { top: 40%; left: 75%; }
     .bottom-left { top: 50%; left: 5%; }
+    .bottom-right { top: 50%; left: 75%; }
 
     .rat-center { /* Styles #centerImage */
         max-width: 70%;

--- a/index.html
+++ b/index.html
@@ -76,6 +76,14 @@
             data-shirt-name="MN Wild jersey"
             data-model-size="XL"
           />
+          <img
+            src="assets/garden-product.png"
+            alt="AI-generated Jon Osmond wearing the gardening shirt"
+            class="shirt bottom-right"
+            data-mouse-src="assets/garden-model.png"
+            data-shirt-name="gardening shirt"
+            data-model-size="M"
+          />
         </div>
       </div>
       <p class="instructions">Drag a shirt onto the center image to try it on.</p>


### PR DESCRIPTION
## Summary
- add gardening shirt asset entry in `index.html`
- add `.bottom-right` styles for desktop and mobile layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad8b790848324858449be29b50c17