### PR TITLE
Enable email submission with Formspree

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ This project powers [jonosmond.com](https://jonosmond.com), showcasing AI genera
 
 All JavaScript is written in vanilla ES modules.
 
+## Enabling Form Submissions
+
+The suggestion form can send entries to your email using a third-party service
+like [Formspree](https://formspree.io/). To enable this:
+
+1. Create a free Formspree account and set up a new form.
+2. Copy the form's endpoint URL (it looks like `https://formspree.io/f/XXXXXX`).
+3. Edit `index.html` and replace `YOUR_FORM_ID` in the form's `action` attribute
+   with your endpoint ID.
+
+Once configured, form submissions will be delivered to the email address you
+registered with Formspree.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
         <nav class="frame__tags">
           <a href="#">#draggable tarps</a>
         </nav>
-        <form id="suggestion-form" class="suggestion-form">
-          <input type="text" name="suggestion" placeholder="Suggest a shirt" />
+        <form id="suggestion-form" class="suggestion-form" action="https://formspree.io/f/YOUR_FORM_ID" method="POST">
+          <input type="text" name="suggestion" required placeholder="Suggest a shirt" />
           <button type="submit">Submit</button>
         </form>
       </header>

--- a/index.js
+++ b/index.js
@@ -10,14 +10,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const infoTooltip = document.getElementById('info-tooltip'); // Select the tooltip element
   const suggestionForm = document.getElementById('suggestion-form');
   if (suggestionForm) {
-    suggestionForm.addEventListener('submit', (e) => {
-      e.preventDefault();
+    suggestionForm.addEventListener('submit', () => {
       const input = suggestionForm.querySelector('input[name="suggestion"]');
       const value = input ? input.value.trim() : '';
       if (value) {
         console.log('Suggestion:', value);
       }
-      if (input) input.value = '';
     });
   }
 


### PR DESCRIPTION
## Summary
- enable form submission through Formspree by setting `action` and `method`
- remove `preventDefault` so form posts normally
- document how to configure Formspree in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aedbc99e4832481eb77250144cc7d