### PR TITLE
Add suggestion form to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This project powers [jonosmond.com](https://jonosmond.com), showcasing AI genera
 
 All JavaScript is written in vanilla ES modules.
 
+## Suggest a Shirt
+
+`index.html` now includes a simple form that posts to [Formspree](https://formspree.io/).
+Replace the `action` attribute value in the markup if you have your own Formspree ID.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/css/base.css
+++ b/css/base.css
@@ -264,6 +264,13 @@ a {
     color: #333;
 }
 
+.suggestion-form {
+    margin: 1rem 0;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
 /* Shirts Area */
 .shirts-container {
     position: relative;

--- a/index.html
+++ b/index.html
@@ -87,6 +87,10 @@
         </div>
       </div>
       <p class="instructions">Drag a shirt onto the center image to try it on.</p>
+      <form class="suggestion-form" action="https://formspree.io/f/xqabqyaa" method="POST">
+        <input type="text" name="suggestion" placeholder="Suggest a new shirt" required />
+        <button type="submit">Submit</button>
+      </form>
     </main>
   
     <script type="module" src="index.js"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,13 @@
 import assert from 'assert';
+import fs from 'fs';
 
 assert.strictEqual(1 + 1, 2);
-console.log('Basic test passed');
+console.log('Basic math test passed');
+
+const html = fs.readFileSync('index.html', 'utf8');
+assert(
+  html.includes('class="suggestion-form"') &&
+    html.includes('formspree.io/f/xqabqyaa'),
+  'Suggestion form markup missing'
+);
+console.log('Form markup exists');


### PR DESCRIPTION
## Summary
- add Formspree suggestion form markup
- style `.suggestion-form`
- document customizing the form in README
- extend tests for new markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af30cc0b88324a33b842a8cdce426