### PR TITLE
Add nodemailer server for shirt suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@ This project powers [jonosmond.com](https://jonosmond.com), showcasing AI genera
 
 ## Development
 
-1. Run a static server (e.g. `npx serve`) in the project root.
-2. Open the served `index.html` in your browser.
+1. Install dependencies with `npm install`.
+2. Start the local server with `npm start` (or `node server.js`).
+   The site will be available at `http://localhost:3000` and also handles
+   form submissions.
 
 All JavaScript is written in vanilla ES modules.
 
 ## Suggest a Shirt
 
-`index.html` now includes a simple form that posts to [Formspree](https://formspree.io/).
-Replace the `action` attribute value in the markup if you have your own Formspree ID.
+`index.html` contains a form that posts to the `/suggest` endpoint served by
+`server.js`.  The server uses `nodemailer` to forward submissions to the address
+specified in the `TARGET_EMAIL` environment variable (falling back to
+`SMTP_USER`).  Configure your SMTP credentials via the `SMTP_HOST`, `SMTP_PORT`,
+`SMTP_USER`, and `SMTP_PASS` environment variables.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         </div>
       </div>
       <p class="instructions">Drag a shirt onto the center image to try it on.</p>
-      <form class="suggestion-form" action="https://formspree.io/f/xqabqyaa" method="POST">
+      <form class="suggestion-form" action="/suggest" method="POST">
         <input type="text" name="suggestion" placeholder="Suggest a new shirt" required />
         <button type="submit">Submit</button>
       </form>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "nodemailer": "^6.9.1"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,70 @@
+import http from 'http';
+import { parse } from 'querystring';
+import nodemailer from 'nodemailer';
+import fs from 'fs';
+import path from 'path';
+
+const port = process.env.PORT || 3000;
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT || '587', 10),
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+function sendIndex(res) {
+  const file = path.join(process.cwd(), 'index.html');
+  fs.createReadStream(file)
+    .on('error', () => {
+      res.writeHead(500);
+      res.end('Server Error');
+    })
+    .pipe(res);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/suggest') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', async () => {
+      const data = parse(body);
+      const suggestion = data.suggestion || '';
+      try {
+        await transporter.sendMail({
+          from: process.env.SMTP_FROM || process.env.SMTP_USER,
+          to: process.env.TARGET_EMAIL || process.env.SMTP_USER,
+          subject: 'New Shirt Suggestion',
+          text: suggestion,
+        });
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('OK');
+      } catch (err) {
+        console.error('Email send failed', err);
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Error');
+      }
+    });
+  } else if (req.method === 'GET' && (req.url === '/' || req.url === '/index.html')) {
+    sendIndex(res);
+  } else {
+    const filePath = path.join(process.cwd(), req.url);
+    fs.stat(filePath, (err, stats) => {
+      if (err || !stats.isFile()) {
+        res.writeHead(404);
+        res.end('Not Found');
+        return;
+      }
+      fs.createReadStream(filePath).pipe(res);
+    });
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ console.log('Basic math test passed');
 const html = fs.readFileSync('index.html', 'utf8');
 assert(
   html.includes('class="suggestion-form"') &&
-    html.includes('formspree.io/f/xqabqyaa'),
+    html.includes('action="/suggest"'),
   'Suggestion form markup missing'
 );
 console.log('Form markup exists');


### PR DESCRIPTION
## Summary
- implement a small Node server using nodemailer to email suggestions
- change form to post to `/suggest`
- document how to run the new server and configure SMTP
- add nodemailer dependency and a `start` script
- update tests for the new form action

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684af754e5f08324b2578a98cea43834