### PR TITLE
Remove Formspree form

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ This project powers [jonosmond.com](https://jonosmond.com), showcasing AI genera
 
 All JavaScript is written in vanilla ES modules.
 
-## Suggest a Shirt
-
-`index.html` now includes a simple form that posts to [Formspree](https://formspree.io/).
-Replace the `action` attribute value in the markup if you have your own Formspree ID.
 
 ## License
 

--- a/css/base.css
+++ b/css/base.css
@@ -264,16 +264,6 @@ a {
     color: #333;
 }
 
-.suggestion-form {
-    position: absolute;
-    top: var(--page-padding);
-    right: var(--page-padding);
-    margin: 0;
-    display: flex;
-    justify-content: center;
-    gap: 0.5rem;
-    z-index: 1000;
-}
 
 /* Shirts Area */
 .shirts-container {

--- a/index.html
+++ b/index.html
@@ -86,11 +86,7 @@
           />
         </div>
       </div>
-      <p class="instructions">Drag a shirt onto the center image to try it on.</p>
-      <form class="suggestion-form" action="https://formspree.io/f/xqabqyaa" method="POST">
-        <input type="text" name="suggestion" placeholder="Suggest a new shirt" required />
-        <button type="submit">Submit</button>
-      </form>
+        <p class="instructions">Drag a shirt onto the center image to try it on.</p>
     </main>
   
     <script type="module" src="index.js"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -5,9 +5,5 @@ assert.strictEqual(1 + 1, 2);
 console.log('Basic math test passed');
 
 const html = fs.readFileSync('index.html', 'utf8');
-assert(
-  html.includes('class="suggestion-form"') &&
-    html.includes('formspree.io/f/xqabqyaa'),
-  'Suggestion form markup missing'
-);
-console.log('Form markup exists');
+assert(!html.includes('formspree.io'), 'Formspree markup should be removed');
+console.log('Formspree markup removed');


### PR DESCRIPTION
## Summary
- remove Formspree-based feedback form
- drop unused form styles
- prune documentation about the form
- update tests to ensure Formspree markup is gone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684afb7a0e348324b7fbcfcc970b9e58