### PR TITLE
Add z-index to suggestion container

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -453,6 +453,7 @@ a {
     position: absolute;
     top: 1rem;
     right: 1rem;
+    z-index: 1010;
     text-align: right;
     color: #000;
     font-family: ui-monospace, monospace;


### PR DESCRIPTION
## Summary
- set z-index for `#suggestion-container` so the suggestions overlay stays above other elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684afe942a508324a5d6632af48c3155