### PR TITLE
Implement scrolling suggestion message

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -508,18 +508,34 @@ a {
     transform: scaleY(1);
 }
 
-#suggestions-list {
-    margin-top: 0.5rem;
-    padding: 0.5rem 1rem;
-    list-style-type: disc;
-    background-color: rgba(255, 255, 255, 0.8);
-    border-radius: 4px;
-    color: #000;
-    max-height: 200px;
-    overflow-y: auto;
-    text-align: left;
+
+.suggest-messages {
+    position: fixed;
+    bottom: 1rem;
+    left: 0;
+    right: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 1010;
+    text-align: center;
 }
 
-#suggestions-list li {
-    margin-bottom: 0.25rem;
+.suggest-marquee {
+    display: inline-block;
+    white-space: nowrap;
+    background-color: rgba(255, 255, 255, 0.9);
+    color: #000;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-family: ui-monospace, monospace;
+    animation: suggest-scroll 10s linear forwards;
+}
+
+@keyframes suggest-scroll {
+    from {
+        transform: translateX(100%);
+    }
+    to {
+        transform: translateX(-100%);
+    }
 }

--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
         <input type="text" id="suggest-input" placeholder="Your shirt idea" />
         <button id="suggest-submit">Submit</button>
       </div>
-      <ul id="suggestions-list" class="suggestions-list"></ul>
     </div>
+    <div id="suggest-messages" class="suggest-messages" aria-live="polite"></div>
     <main>
       <header class="frame">
         <h1 class="frame__title">Jon Osmond</h1>

--- a/index.js
+++ b/index.js
@@ -12,16 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestInputContainer = document.getElementById('suggest-input-container');
   const suggestInput = document.getElementById('suggest-input');
   const suggestSubmit = document.getElementById('suggest-submit');
-  const suggestionsList = document.getElementById('suggestions-list');
+  const suggestMessagesContainer = document.getElementById('suggest-messages');
 
-  const STORAGE_KEY = 'suggestionsList';
-
-  const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
-  saved.forEach((text) => {
-    const li = document.createElement('li');
-    li.textContent = text;
-    suggestionsList.appendChild(li);
-  });
 
   // --- Configuration and Constants ---
   const MODEL_INFO = {
@@ -442,7 +434,7 @@ document.addEventListener('DOMContentLoaded', () => {
   updateTooltip();
 
   // --- Suggestion Feature ---
-  if (suggestLink && suggestInputContainer && suggestInput && suggestSubmit && suggestionsList) {
+  if (suggestLink && suggestInputContainer && suggestInput && suggestSubmit && suggestMessagesContainer) {
     suggestLink.addEventListener('click', (event) => {
       event.preventDefault();
       suggestInputContainer.classList.toggle('open');
@@ -455,11 +447,13 @@ document.addEventListener('DOMContentLoaded', () => {
       event.preventDefault();
       const text = suggestInput.value.trim();
       if (text) {
-        const li = document.createElement('li');
-        li.textContent = text;
-        suggestionsList.appendChild(li);
-        const entries = [...suggestionsList.querySelectorAll('li')].map((li) => li.textContent);
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+        const message = document.createElement('div');
+        message.className = 'suggest-marquee';
+        message.textContent = `that's a great idea I would love to see him wearing ${text}! Please email me so I don't forget`;
+        suggestMessagesContainer.appendChild(message);
+        message.addEventListener('animationend', () => {
+          message.remove();
+        });
         suggestInput.value = '';
         suggestInputContainer.classList.remove('open');
         suggestLink.focus();


### PR DESCRIPTION
## Summary
- add a container for suggestion messages
- remove old list styling and implement marquee styles
- show scrolling text with user's suggestion instead of appending to a list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b070766d08324a1e1c2d7528afc35