### PR TITLE
Update suggestion banner placement and speed

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -449,7 +449,6 @@ a {
 }
 
 /* Suggestion feature */
-#suggestion-container,
 .suggestion-container {
     position: absolute;
     top: 1rem;
@@ -508,7 +507,7 @@ a {
 .suggest-messages {
     position: fixed;
 
-    top: 1rem;
+    top: 0;
 
     left: 0;
     right: 0;
@@ -527,7 +526,7 @@ a {
     border-radius: 6px;
     font-family: ui-monospace, monospace;
 
-    animation: suggest-scroll 20s linear forwards;
+    animation: suggest-scroll 35s linear forwards;
 
 }
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <noscript>
       <p class="instructions">This page requires JavaScript for the drag-and-drop demo.</p>
     </noscript>
-    <div id="suggestion-container" class="suggestion-container">
+    <div id="suggestion-container">
       <a id="suggest-link" href="#">Suggest a shirt</a>
       <div id="suggest-input-container" class="suggest-input-container">
         <input type="text" id="suggest-input" placeholder="Your shirt idea" />


### PR DESCRIPTION
## Summary
- remove styling from `#suggestion-container`
- scroll suggestion banner more slowly and show it flush with the top

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0a6196688324b1568e6c496e98e6