### PR TITLE
Improve suggestion input validation

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -473,6 +473,17 @@ a {
     font-family: inherit;
 }
 
+#suggest-error {
+    color: #d00;
+    margin-top: 0.25rem;
+    font-size: 0.9rem;
+    display: none;
+}
+
+#suggest-error.visible {
+    display: block;
+}
+
 #suggest-submit {
     margin-left: 0.5rem;
     padding: 0.3rem 0.75rem;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       <div id="suggest-input-container" class="suggest-input-container">
         <input type="text" id="suggest-input" placeholder="Your shirt idea" />
         <button id="suggest-submit">Submit</button>
+        <div id="suggest-error" class="suggest-error" aria-live="polite"></div>
       </div>
     </div>
     <div id="suggest-messages" class="suggest-messages" aria-live="polite"></div>

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestInput = document.getElementById('suggest-input');
   const suggestSubmit = document.getElementById('suggest-submit');
   const suggestMessagesContainer = document.getElementById('suggest-messages');
+  const suggestError = document.getElementById('suggest-error');
 
 
   // --- Configuration and Constants ---
@@ -439,6 +440,10 @@ document.addEventListener('DOMContentLoaded', () => {
       event.preventDefault();
       suggestInputContainer.classList.toggle('open');
       if (suggestInputContainer.classList.contains('open')) {
+        if (suggestError) {
+          suggestError.textContent = '';
+          suggestError.classList.remove('visible');
+        }
         suggestInput.focus();
       }
     });
@@ -446,6 +451,29 @@ document.addEventListener('DOMContentLoaded', () => {
     function handleSuggestSubmit(event) {
       event.preventDefault();
       const text = suggestInput.value.trim();
+      let errorMessage = '';
+
+      if (!text) {
+        errorMessage = 'Please enter a shirt idea.';
+      } else if (text.length > 60) {
+        errorMessage = 'Shirt idea must be 60 characters or fewer.';
+      } else if (!/^[a-zA-Z0-9 ,.!?'-]+$/.test(text)) {
+        errorMessage = 'Shirt idea contains invalid characters.';
+      }
+
+      if (errorMessage) {
+        if (suggestError) {
+          suggestError.textContent = errorMessage;
+          suggestError.classList.add('visible');
+        }
+        return;
+      }
+
+      if (suggestError) {
+        suggestError.textContent = '';
+        suggestError.classList.remove('visible');
+      }
+
       if (text) {
         const wrapper = document.createElement('div');
         wrapper.className = 'suggest-marquee';


### PR DESCRIPTION
## Summary
- add client-side validation for shirt suggestion input
- show error messages via new `suggest-error` element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0f6d97988324ba59e45709a7f6b8