### PR TITLE
Move tooltip next to instructions

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -343,24 +343,22 @@ a {
 
 /* Tooltip for Model Info */
 #info-tooltip {
-    position: absolute;
-    top: 25%; 
-    left: 55%; 
-    transform: translate(-50%, -50%); 
-    width: 18px; 
-    height: 18px; 
-    color: rgba(0, 0, 0, 0.6); 
-    border: 1px solid rgba(0, 0, 0, 0.6); 
+    position: relative;
+    width: 18px;
+    height: 18px;
+    margin-left: 0.25rem;
+    color: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(0, 0, 0, 0.6);
     border-radius: 50%;
-    display: flex;
+    display: inline-flex;
     justify-content: center;
     align-items: center;
-    font-size: 11px; 
+    font-size: 11px;
     font-weight: bold;
     cursor: help;
-    z-index: 15; 
-    transition: border-color 0.2s ease, color 0.2s ease; 
-    font-family: sans-serif; 
+    z-index: 15;
+    transition: border-color 0.2s ease, color 0.2s ease;
+    font-family: sans-serif;
 }
 
 #info-tooltip:hover {
@@ -426,24 +424,12 @@ a {
 
     }
 
-    #info-tooltip { 
-        top: 25%;
-        left: 65%;
-    }
 
 }
 
 @media (max-width: 377px) {
-    #info-tooltip { 
-        top: 25%;
-        left: 65%;
-    }
 }
 @media (min-width: 378px) and (max-width: 429px) {
-    #info-tooltip {
-        top: 25%;
-        left: 65%;
-    }
 }
 
 /* Suggestion feature */

--- a/index.html
+++ b/index.html
@@ -68,7 +68,6 @@
             data-model-size="L"
           />
           <img src="assets/white-tshirt-model.png" alt="AI-generated Jon Osmond wearing the white T-shirt" class="rat-center" id="centerImage" />
-          <span id="info-tooltip" aria-label="Model information" tabindex="0" data-tooltip="This is not Jon Osmond">?</span>
           <img
             src="assets/metal-tshirt-product.png"
             alt="AI-generated Jon Osmond wearing the metal T-shirt"
@@ -95,7 +94,10 @@
           />
         </div>
       </div>
-        <p class="instructions">Drag a shirt onto the center image to try it on.</p>
+        <p class="instructions">
+          Drag a shirt onto the center image to try it on.
+          <span id="info-tooltip" aria-label="Model information" tabindex="0" data-tooltip="This is not Jon Osmond">?</span>
+        </p>
     </main>
   
     <script type="module" src="index.js"></script>


### PR DESCRIPTION
## Summary
- place the info tooltip inside the instructions paragraph
- style tooltip for inline placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b14d1c02c832487f1d0b060df5296