### PR TITLE
Add smooth underline effect on link hover

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -85,9 +85,23 @@ a {
   outline: none;
   cursor: pointer;
   position: relative;
+  /* Underline effect */
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    width: 0;
+    height: 2px;
+    background: currentColor;
+    transition: width 0.2s ease-in-out;
+  }
 
   &:hover {
     color: var(--color-link-hover);
+    &::after {
+      width: 100%;
+    }
   }
 
   &:focus {


### PR DESCRIPTION
## Summary
- add pseudo-element animation for `<a>` tags to smoothly display an underline on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b1600587c832482c09dd61ac1548a