### PR TITLE
Add npm start script for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This project powers [jonosmond.com](https://jonosmond.com), showcasing AI genera
 1. Install dependencies with `npm install`. There are currently no external
    packages, but this step prepares the project for future additions.
 2. Run the test suite with `npm test`.
-3. Start a static server (e.g. `npx serve`) in the project root and open the
-   served `index.html` in your browser.
+3. Launch the site with `npm start`, which runs a lightweight static server,
+   and open the served `index.html` in your browser.
 
 All JavaScript is written in vanilla ES modules.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "start": "npx serve -s ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add an npm start command using `serve`
- document the new `npm start` usage in development instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b2b969f5c8324af8e1e9931c05a22