### PR TITLE
Add keyboard drag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ All JavaScript is written in vanilla ES modules.
 The GitHub Actions workflow runs `npm install` and `npm test` on every push and
 pull request to ensure the site continues to build successfully.
 
+## Keyboard Controls
+
+Each shirt image can be focused with the Tab key. Press **Space** or **Enter** to grab the
+focused shirt. While a shirt is grabbed, use the arrow keys to move it around
+the page. Press **Space** or **Enter** again to drop the shirt and, if it is
+over the center image, try it on.
+
 
 ## License
 

--- a/css/base.css
+++ b/css/base.css
@@ -259,6 +259,14 @@ a:focus-visible {
 
 }
 
+.shirt:focus {
+    outline: none;
+}
+
+.shirt:focus-visible {
+    outline: 2px solid red;
+}
+
 .shirt.grabbed {
     transform: scale(1.05);
 

--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let moveTimeout; // Timeout ID for managing dragging class changes.
   let originalCenterImageSrc = ''; // Stores the full URL of the base image displayed on centerImage *before* any hover effects during a drag. This is crucial for reverting after a hover.
   let isHoveringCenterImage = false; // Flag to track if a dragged shirt is currently hovering over the centerImage and has triggered a hover image change.
+  let keyboardDragging = false; // True when a drag is initiated via keyboard
 
   // --- Helper Functions ---
 
@@ -126,6 +127,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize each shirt for drag-and-drop.
   shirts.forEach((shirt) => {
     shirt.style.cursor = 'grab'; // Set the cursor to 'grab' to indicate draggable items.
+    shirt.tabIndex = 0; // Make shirts focusable for keyboard users
+
     // Add touch and mouse event listeners for starting the drag.
     // { passive: false } for touchstart allows us to call e.preventDefault().
     shirt.addEventListener(
@@ -138,6 +141,9 @@ document.addEventListener('DOMContentLoaded', () => {
     shirt.addEventListener('mousedown', (e) => {
       handleStart(e);
     });
+
+    // Keyboard support
+    shirt.addEventListener('keydown', handleShirtKeydown);
   });
 
   // --- Drag-and-Drop Event Handlers ---
@@ -432,6 +438,127 @@ document.addEventListener('DOMContentLoaded', () => {
 
     isHoveringCenterImage = false; // Ensure hover state is reset.
     activeShirt = null; // Clear the active shirt.
+    keyboardDragging = false;
+  }
+
+  // --- Keyboard Dragging Support ---
+  const KEYBOARD_STEP = 10; // pixels moved per arrow press
+
+  function handleShirtKeydown(event) {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      if (!keyboardDragging) {
+        startKeyboardDrag(event.currentTarget);
+      } else if (activeShirt === event.currentTarget) {
+        handleEnd();
+      }
+    } else if (keyboardDragging && activeShirt === event.currentTarget) {
+      let moved = false;
+      if (event.key === 'ArrowUp') {
+        currentPos.y -= KEYBOARD_STEP;
+        moved = true;
+      } else if (event.key === 'ArrowDown') {
+        currentPos.y += KEYBOARD_STEP;
+        moved = true;
+      } else if (event.key === 'ArrowLeft') {
+        currentPos.x -= KEYBOARD_STEP;
+        moved = true;
+      } else if (event.key === 'ArrowRight') {
+        currentPos.x += KEYBOARD_STEP;
+        moved = true;
+      }
+
+      if (moved) {
+        event.preventDefault();
+        activeShirt.style.left = `${currentPos.x}px`;
+        activeShirt.style.top = `${currentPos.y}px`;
+        updateHoverState();
+      }
+    }
+  }
+
+  function startKeyboardDrag(target) {
+    activeShirt = target;
+
+    // Capture the base version of the centerImage src as in handleStart
+    if (centerImage && centerImage.src) {
+      let currentCenterSrcURL;
+      try {
+        currentCenterSrcURL = new URL(centerImage.src, window.location.href);
+      } catch {
+        originalCenterImageSrc = centerImage.src;
+        isHoveringCenterImage = false;
+      }
+
+      if (currentCenterSrcURL) {
+        const currentCenterPath = currentCenterSrcURL.pathname;
+        const hoverSuffix = 'model-hover.png';
+        const baseSuffix = 'model.png';
+
+        if (currentCenterPath.endsWith(hoverSuffix)) {
+          const basePath = currentCenterPath.replace(hoverSuffix, baseSuffix);
+          try {
+            originalCenterImageSrc = new URL(basePath, window.location.href).href;
+          } catch {
+            originalCenterImageSrc = currentCenterSrcURL.href;
+          }
+        } else {
+          originalCenterImageSrc = currentCenterSrcURL.href;
+        }
+      }
+    }
+
+    isHoveringCenterImage = false;
+
+    const computedStyle = window.getComputedStyle(activeShirt);
+    initialShirtPos.left = computedStyle.left || '0px';
+    initialShirtPos.top = computedStyle.top || '0px';
+    currentPos.x = parseInt(initialShirtPos.left) || 0;
+    currentPos.y = parseInt(initialShirtPos.top) || 0;
+
+    activeShirt.style.cursor = 'grabbing';
+    activeShirt.style.zIndex = '1000';
+    activeShirt.classList.add('grabbed');
+    keyboardDragging = true;
+  }
+
+  function updateHoverState() {
+    if (!activeShirt || !centerImage) return;
+
+    const shirtRect = activeShirt.getBoundingClientRect();
+    const centerImageRect = centerImage.getBoundingClientRect();
+    const collision = !(
+      shirtRect.right < centerImageRect.left ||
+      shirtRect.left > centerImageRect.right ||
+      shirtRect.bottom < centerImageRect.top ||
+      shirtRect.top > centerImageRect.bottom
+    );
+
+    if (collision) {
+      const currentDisplaySrcPath = new URL(centerImage.src, window.location.href).pathname;
+      const hoverSuffix = 'model-hover.png';
+      const isAlreadyHovering = currentDisplaySrcPath.endsWith(hoverSuffix);
+
+      if (!isAlreadyHovering && originalCenterImageSrc) {
+        let baseImageToHoverPath;
+        try {
+          baseImageToHoverPath = new URL(originalCenterImageSrc, window.location.href).pathname;
+        } catch {
+          baseImageToHoverPath = '';
+        }
+
+        if (baseImageToHoverPath.endsWith('model.png')) {
+          const potentialHoverPathForOriginal = baseImageToHoverPath.replace('model.png', hoverSuffix);
+          if (validHoverPaths.includes(potentialHoverPathForOriginal)) {
+            centerImage.src = potentialHoverPathForOriginal;
+            isHoveringCenterImage = true;
+          }
+        }
+      }
+    } else if (isHoveringCenterImage && originalCenterImageSrc) {
+      centerImage.src = originalCenterImageSrc;
+      isHoveringCenterImage = false;
+    }
   }
 
   // --- Tooltip Interaction ---


### PR DESCRIPTION
## Summary
- make shirts focusable with tabindex and highlight on focus
- add keyboard dragging: space/enter to grab/drop, arrow keys to move
- document keyboard controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b62cf1d5883249c84c6864c3f66f3