### PR TITLE
Fix mobile viewport styling

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -182,7 +182,7 @@ a:focus-visible {
   padding: var(--page-padding);
   display: flex;
   flex-direction: column;
-  width: 100vw;
+  width: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- remove viewport-breaking `width: 100vw` from `.content`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b8e5bebe08324879777f3c4b7e20b