### PR TITLE
Add shuffle button

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -436,7 +436,26 @@ a:focus-visible {
     align-items: center;
 }
 
+#shuffle-button {
+    cursor: pointer;
+    padding: 0.3rem 0.75rem;
+    border: none;
+    border-radius: 4px;
+    background-color: var(--color-link);
+    color: #fff;
+    font-size: 1rem;
+    font-family: inherit;
+    transition: background-color 0.2s ease;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+}
+
 #suggest-link:hover {
+    background-color: var(--color-link-hover);
+}
+
+#shuffle-button:hover {
     background-color: var(--color-link-hover);
 }
 

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
           <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
       </button>
+      <button id="shuffle-button" type="button">Shuffle shirts</button>
       <div id="suggest-input-container" class="suggest-input-container">
         <input type="text" id="suggest-input" placeholder="Your shirt idea" />
         <button id="suggest-submit" aria-label="Submit">

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestSubmit = document.getElementById('suggest-submit');
   const suggestMessagesContainer = document.getElementById('suggest-messages');
   const suggestError = document.getElementById('suggest-error');
+  const shuffleButton = document.getElementById('shuffle-button');
 
 
   // --- Configuration and Constants ---
@@ -134,6 +135,12 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('All images preloaded, loading class removed.');
     }
   }); // Preload all collected unique image paths and remove loading class on completion.
+
+  if (shuffleButton) {
+    shuffleButton.addEventListener('click', () => {
+      randomizeShirtPositions();
+    });
+  }
 
   // --- Drag-and-Drop State Variables ---
   let activeShirt = null; // The shirt element currently being dragged.


### PR DESCRIPTION
## Summary
- provide a Shuffle shirts button next to the suggestion form
- style the new shuffle button
- randomize shirt positions when the button is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c263e56708324ab6dd9d9eb2e9e89