### PR TITLE
Persist shirt suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ focused shirt. While a shirt is grabbed, use the arrow keys to move it around
 the page. Press **Space** or **Enter** again to drop the shirt and, if it is
 over the center image, try it on.
 
+## Suggesting Shirts
+
+Click the **Suggest a shirt** button in the top corner to share ideas for new designs.
+Suggestions are saved in your browser's local storage so they appear again the next
+time you visit the page.
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -626,6 +626,58 @@ document.addEventListener('DOMContentLoaded', () => {
   updateTooltip();
 
   // --- Suggestion Feature ---
+  const SUGGEST_STORAGE_KEY = 'shirtSuggestions';
+
+  function loadSuggestions() {
+    try {
+      const data = localStorage.getItem(SUGGEST_STORAGE_KEY);
+      return data ? JSON.parse(data) : [];
+    } catch (err) {
+      if (isDev) {
+        console.warn('Failed to load suggestions from storage', err);
+      }
+      return [];
+    }
+  }
+
+  function saveSuggestions(list) {
+    try {
+      localStorage.setItem(SUGGEST_STORAGE_KEY, JSON.stringify(list));
+    } catch (err) {
+      if (isDev) {
+        console.warn('Failed to save suggestions to storage', err);
+      }
+    }
+  }
+
+  function displaySuggestion(text) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'suggest-marquee';
+
+    const bird = document.createElement('span');
+    bird.className = 'suggest-bird';
+    bird.textContent = '🕺';
+
+    const messageText = document.createElement('span');
+    messageText.className = 'suggest-text';
+    messageText.textContent = `That's a great idea! I would love to see him wearing ${text}!`;
+
+    wrapper.appendChild(bird);
+    wrapper.appendChild(messageText);
+    suggestMessagesContainer.appendChild(wrapper);
+
+    wrapper.addEventListener('animationend', () => {
+      wrapper.remove();
+    });
+  }
+
+  // Show any previously saved suggestions when the page loads
+  loadSuggestions().forEach((s) => {
+    if (s && s.text) {
+      displaySuggestion(s.text);
+    }
+  });
+
   if (suggestLink && suggestInputContainer && suggestInput && suggestSubmit && suggestMessagesContainer) {
     suggestLink.addEventListener('click', (event) => {
       event.preventDefault();
@@ -670,24 +722,11 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (text) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'suggest-marquee';
+        displaySuggestion(text);
 
-        const bird = document.createElement('span');
-        bird.className = 'suggest-bird';
-        bird.textContent = '🕺';
-
-        const messageText = document.createElement('span');
-        messageText.className = 'suggest-text';
-        messageText.textContent = `That's a great idea! I would love to see him wearing ${text}!`;
-
-        wrapper.appendChild(bird);
-        wrapper.appendChild(messageText);
-        suggestMessagesContainer.appendChild(wrapper);
-
-        wrapper.addEventListener('animationend', () => {
-          wrapper.remove();
-        });
+        const stored = loadSuggestions();
+        stored.push({ text, time: Date.now() });
+        saveSuggestions(stored);
 
         suggestInput.value = '';
         suggestInputContainer.classList.remove('open');


### PR DESCRIPTION
## Summary
- store submitted shirt ideas in `localStorage`
- replay stored suggestions on page load
- document the new persistence feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c2711b788832483e0bbe47cae6654