### PR TITLE
Remove dancing emoji and related styles

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -592,30 +592,12 @@ a:focus-visible {
     font-family: ui-monospace, monospace;
 }
 
-.suggest-bird {
-    font-size: 1.5rem;
-    margin-right: 0.5rem;
-    position: relative;
-    animation: bird-flap 0.6s ease-in-out infinite;
-}
-
-
-
 @keyframes suggest-scroll {
     from {
         transform: translateX(100%);
     }
     to {
         transform: translateX(-100%);
-    }
-}
-
-@keyframes bird-flap {
-    0%, 100% {
-        transform: translateY(0);
-    }
-    50% {
-        transform: translateY(-4px);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -671,10 +671,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const wrapper = document.createElement('div');
     wrapper.className = 'suggest-marquee';
 
-    const bird = document.createElement('span');
-    bird.className = 'suggest-bird';
-    bird.textContent = '🕺';
-
     const messageText = document.createElement('span');
     messageText.className = 'suggest-text';
 
@@ -686,7 +682,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
 
-    wrapper.appendChild(bird);
     wrapper.appendChild(messageText);
     suggestMessagesContainer.appendChild(wrapper);
 


### PR DESCRIPTION
## Summary
- finish removing the dancing emoji markup from the suggestion marquee
- delete `.suggest-bird` and `bird-flap` styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c455f776c83249cb88fe21ee2529a