### PR TITLE
Randomize suggestion popups

### DIFF
--- a/index.js
+++ b/index.js
@@ -671,6 +671,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const wrapper = document.createElement('div');
     wrapper.className = 'suggest-marquee';
 
+    // Randomize position so multiple messages don't overlap in a single row
+    // Position is fixed so it remains relative to the viewport
+    wrapper.style.position = 'fixed';
+    wrapper.style.top = `${10 + Math.random() * 80}%`;
+    wrapper.style.left = `${5 + Math.random() * 90}%`;
+
     const messageText = document.createElement('span');
     messageText.className = 'suggest-text';
 


### PR DESCRIPTION
## Summary
- show suggestion marquees at fixed random positions so they don't line up horizontally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c48794bb88324b2d7f13e62119750