### PR TITLE
Shorten marquee scroll duration

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -579,7 +579,7 @@ a:focus-visible {
     display: inline-flex;
     align-items: flex-end;
     white-space: nowrap;
-    animation: suggest-scroll 35s linear forwards;
+    animation: suggest-scroll 20s linear forwards;
     position: relative;
     pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- shorten the `.suggest-marquee` animation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c49d3280083248be77461776f5a85