### PR TITLE
Add shirt-change animation

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -601,3 +601,19 @@ a:focus-visible {
     }
 }
 
+.rat-center.change-effect {
+    animation: change-bounce 0.3s ease-out;
+}
+
+@keyframes change-bounce {
+    0% {
+        transform: translate(-50%, -50%) scale(0.95);
+    }
+    50% {
+        transform: translate(-50%, -50%) scale(1.05);
+    }
+    100% {
+        transform: translate(-50%, -50%) scale(1);
+    }
+}
+

--- a/index.js
+++ b/index.js
@@ -440,6 +440,15 @@ document.addEventListener('DOMContentLoaded', () => {
           centerImage.alt = `AI-generated Jon Osmond wearing the ${shirtName}`;
         }
 
+        centerImage.classList.add('change-effect');
+        centerImage.addEventListener(
+          'animationend',
+          () => {
+            centerImage.classList.remove('change-effect');
+          },
+          { once: true }
+        );
+
         updateTooltip(); // Update tooltip based on the new model/shirt.
 
         // Reset the dragged shirt's position back to its initial spot.


### PR DESCRIPTION
## Summary
- add a bounce animation for the center image when changing shirts
- trigger the animation in the drag end handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5289db608324beb4ddc09d23daab