### PR TITLE
Add optional first-drop sound effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This project powers [jonosmond.com](https://jonosmond.com), showcasing AI genera
    package, which starts a lightweight static server on
    [http://localhost:3000](http://localhost:3000) by default. Open the served
    `index.html` in your browser.
+4. Optionally add a sound effect by placing an MP3 named `first-drop.mp3` in the
+   `assets/` directory. It will play the first time a shirt is placed on the
+   model during a session.
 
 All JavaScript is written in vanilla ES modules.
 

--- a/index.html
+++ b/index.html
@@ -118,6 +118,10 @@
         </p>
     </main>
   
+    <audio id="first-drop-audio" preload="auto">
+      <source src="assets/first-drop.mp3" type="audio/mpeg" />
+    </audio>
+
     <script type="module" src="index.js"></script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestMessagesContainer = document.getElementById('suggest-messages');
   const suggestError = document.getElementById('suggest-error');
   const shuffleButton = document.getElementById('shuffle-button');
+  const firstDropAudio = document.getElementById('first-drop-audio');
 
 
   // --- Configuration and Constants ---
@@ -31,6 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // --- State Variables ---
   const validHoverPaths = []; // Stores absolute URL pathnames for valid hover images (e.g., ".../white-tshirt-model-hover.png"). Used to ensure we only attempt to load existing hover images.
+  let hasPlayedFirstDrop = false;
 
   // --- Image Path Collection and Preloading ---
   // Gather all potential image sources from the HTML to preload them.
@@ -450,6 +452,13 @@ document.addEventListener('DOMContentLoaded', () => {
         );
 
         updateTooltip(); // Update tooltip based on the new model/shirt.
+
+        if (!hasPlayedFirstDrop && firstDropAudio) {
+          try {
+            firstDropAudio.play();
+          } catch (e) {}
+          hasPlayedFirstDrop = true;
+        }
 
         // Reset the dragged shirt's position back to its initial spot.
         activeShirt.style.left = initialShirtPos.left;


### PR DESCRIPTION
## Summary
- add `first-drop-audio` element to play a sound when the first shirt is placed
- trigger audio playback once in `handleEnd`
- document how to use an MP3 named `first-drop.mp3`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c588ddf0083248d3733655ee9b01e