### PR TITLE
Add Playwright UI tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "node test/test.js",
+    "test": "playwright test",
     "start": "npx serve -s ."
   },
   "devDependencies": {
-    "serve": "^14.2.0"
+    "serve": "^14.2.0",
+    "@playwright/test": "^1.41.2"
   },
   "keywords": [],
   "author": "",

--- a/test/ui.spec.js
+++ b/test/ui.spec.js
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const fileUrl = 'file://' + path.resolve('index.html');
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(fileUrl);
+});
+
+test('dragging a shirt updates the center image', async ({ page }) => {
+  const target = page.locator('img[data-shirt-name="metal T-shirt"]');
+  const center = page.locator('#centerImage');
+  await target.dragTo(center);
+  await expect(center).toHaveAttribute('src', /metal-tshirt-model\.png$/);
+});
+
+test('submitting a suggestion stores it in localStorage', async ({ page }) => {
+  await page.click('#suggest-link');
+  await page.fill('#suggest-input', 'blue shirt');
+  await page.click('#suggest-submit');
+  const stored = await page.evaluate(() => localStorage.getItem('shirtSuggestions'));
+  expect(stored).not.toBeNull();
+  const items = JSON.parse(stored);
+  expect(items[items.length - 1].text).toBe('blue shirt');
+});
+
+test('keyboard dragging moves shirt onto model', async ({ page }) => {
+  const jersey = page.locator('img[data-shirt-name="MN Wild jersey"]');
+  const center = page.locator('#centerImage');
+  await jersey.focus();
+  await page.keyboard.press('Space');
+  for (let i = 0; i < 40; i++) await page.keyboard.press('ArrowLeft');
+  for (let i = 0; i < 10; i++) await page.keyboard.press('ArrowUp');
+  await page.keyboard.press('Enter');
+  await expect(center).toHaveAttribute('src', /mn-wild-jersey-model\.png$/);
+});


### PR DESCRIPTION
## Summary
- add Playwright test runner to package.json
- write browser tests for dragging shirts, submitting suggestions and keyboard drag support

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c712d069883248f95a28261f270a2