### PR TITLE
Prevent overlapping audio effects

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const suitCheeseAudio = document.getElementById('suit-cheese-audio');
 
+  function playAudioExclusive(audioElement) {
+    if (!audioElement) return;
+    const audios = [firstDropAudio, suitCheeseAudio];
+    audios.forEach((aud) => {
+      if (aud && aud !== audioElement) {
+        aud.pause();
+        try {
+          aud.currentTime = 0;
+        } catch (e) {}
+      }
+    });
+    try {
+      audioElement.play();
+    } catch (e) {}
+  }
+
 
 
   // --- Configuration and Constants ---
@@ -458,16 +474,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
         if (shirtName === 'suit' && suitCheeseAudio) {
-          try {
-            suitCheeseAudio.play();
-          } catch (e) {}
+          playAudioExclusive(suitCheeseAudio);
         }
 
 
         if (!hasPlayedFirstDrop && firstDropAudio) {
-          try {
-            firstDropAudio.play();
-          } catch (e) {}
+          playAudioExclusive(firstDropAudio);
           hasPlayedFirstDrop = true;
         }
 


### PR DESCRIPTION
## Summary
- add a `playAudioExclusive` helper
- use the helper when playing drop sounds so only one audio plays at a time

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c739ef0108324bc44d5626f71015c