### PR TITLE
Add mute sound toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ This project powers [jonosmond.com](https://jonosmond.com), showcasing AI genera
 5. Optionally include another MP3 named `cheese.mp3` in the `assets/` directory.
    It will play whenever the suit shirt is placed on the model.
 
+6. Use the **Mute sound** button in the top corner to toggle audio playback. The
+   preference is saved in your browser.
+
 
 All JavaScript is written in vanilla ES modules.
 

--- a/css/base.css
+++ b/css/base.css
@@ -462,11 +462,31 @@ a:focus-visible {
     align-items: center;
 }
 
+#mute-toggle {
+    cursor: pointer;
+    padding: 0.3rem 0.75rem;
+    border: none;
+    border-radius: 4px;
+    background-color: var(--color-link);
+    color: #fff;
+    font-size: 1rem;
+    font-family: inherit;
+    transition: background-color 0.2s ease;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    margin-left: 0.5rem;
+}
+
 #suggest-link:hover {
     background-color: var(--color-link-hover);
 }
 
 #shuffle-button:hover {
+    background-color: var(--color-link-hover);
+}
+
+#mute-toggle:hover {
     background-color: var(--color-link-hover);
 }
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,8 @@
           <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
       </button>
-        <button id="shuffle-button" type="button" aria-label="Shuffle shirt positions">Shuffle shirts</button>
+      <button id="shuffle-button" type="button" aria-label="Shuffle shirt positions">Shuffle shirts</button>
+      <button id="mute-toggle" type="button" aria-pressed="false">Mute sound</button>
       <div id="suggest-input-container" class="suggest-input-container">
         <input type="text" id="suggest-input" placeholder="Your shirt idea" />
         <button id="suggest-submit" aria-label="Submit">

--- a/index.js
+++ b/index.js
@@ -21,12 +21,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestMessagesContainer = document.getElementById('suggest-messages');
   const suggestError = document.getElementById('suggest-error');
   const shuffleButton = document.getElementById('shuffle-button');
+  const muteToggle = document.getElementById('mute-toggle');
   const firstDropAudio = document.getElementById('first-drop-audio');
 
   const suitCheeseAudio = document.getElementById('suit-cheese-audio');
 
   function playAudioExclusive(audioElement) {
-    if (!audioElement) return;
+    if (!audioElement || isMuted) return;
     const audios = [firstDropAudio, suitCheeseAudio];
     audios.forEach((aud) => {
       if (aud && aud !== audioElement) {
@@ -52,6 +53,36 @@ document.addEventListener('DOMContentLoaded', () => {
   // --- State Variables ---
   const validHoverPaths = []; // Stores absolute URL pathnames for valid hover images (e.g., ".../white-tshirt-model-hover.png"). Used to ensure we only attempt to load existing hover images.
   let hasPlayedFirstDrop = false;
+  const MUTE_STORAGE_KEY = 'muteSound';
+  let isMuted = false;
+
+  function loadMuteSetting() {
+    try {
+      return localStorage.getItem(MUTE_STORAGE_KEY) === 'true';
+    } catch (err) {
+      if (isDev) {
+        console.warn('Failed to load mute preference', err);
+      }
+      return false;
+    }
+  }
+
+  function saveMuteSetting(val) {
+    try {
+      localStorage.setItem(MUTE_STORAGE_KEY, val ? 'true' : 'false');
+    } catch (err) {
+      if (isDev) {
+        console.warn('Failed to save mute preference', err);
+      }
+    }
+  }
+
+  function updateMuteToggle() {
+    if (muteToggle) {
+      muteToggle.textContent = isMuted ? 'Unmute sound' : 'Mute sound';
+      muteToggle.setAttribute('aria-pressed', String(isMuted));
+    }
+  }
 
   // --- Image Path Collection and Preloading ---
   // Gather all potential image sources from the HTML to preload them.
@@ -146,6 +177,16 @@ document.addEventListener('DOMContentLoaded', () => {
       } while (overlaps && attempts < MAX_ATTEMPTS);
 
       placed.push(shirt.getBoundingClientRect());
+    });
+  }
+
+  isMuted = loadMuteSetting();
+  updateMuteToggle();
+  if (muteToggle) {
+    muteToggle.addEventListener('click', () => {
+      isMuted = !isMuted;
+      saveMuteSetting(isMuted);
+      updateMuteToggle();
     });
   }
 


### PR DESCRIPTION
## Summary
- add mute sound button in the suggestion bar
- store audio preference in localStorage and respect it when playing sounds
- style the mute toggle
- document how to mute audio

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c792d7bf08324aa9746ea72793f23