### PR TITLE
Add ability to clear suggestions

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -462,11 +462,30 @@ a:focus-visible {
     align-items: center;
 }
 
+#clear-suggestions {
+    cursor: pointer;
+    padding: 0.3rem 0.75rem;
+    border: none;
+    border-radius: 4px;
+    background-color: var(--color-link);
+    color: #fff;
+    font-size: 1rem;
+    font-family: inherit;
+    transition: background-color 0.2s ease;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+}
+
 #suggest-link:hover {
     background-color: var(--color-link-hover);
 }
 
 #shuffle-button:hover {
+    background-color: var(--color-link-hover);
+}
+
+#clear-suggestions:hover {
     background-color: var(--color-link-hover);
 }
 

--- a/index.html
+++ b/index.html
@@ -23,18 +23,19 @@
       <p class="instructions">This page requires JavaScript for the drag-and-drop demo.</p>
     </noscript>
     <div id="suggestion-container">
-      <button id="suggest-link" type="button">
-        Suggest a shirt
-        <svg class="toggle-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
+        <button id="suggest-link" type="button">
+          Suggest a shirt
+          <svg class="toggle-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
         <button id="shuffle-button" type="button" aria-label="Shuffle shirt positions">Shuffle shirts</button>
-      <div id="suggest-input-container" class="suggest-input-container">
-        <input type="text" id="suggest-input" placeholder="Your shirt idea" />
-        <button id="suggest-submit" aria-label="Submit">
-          <svg class="submit-arrow" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M2 12h16M12 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <button id="clear-suggestions" type="button" aria-label="Clear stored suggestions">Clear suggestions</button>
+        <div id="suggest-input-container" class="suggest-input-container">
+          <input type="text" id="suggest-input" placeholder="Your shirt idea" />
+          <button id="suggest-submit" aria-label="Submit">
+            <svg class="submit-arrow" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 12h16M12 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </button>
         <div id="suggest-error" class="suggest-error" aria-live="polite"></div>
@@ -62,7 +63,7 @@
           >
 
         </div>
-      
+
         <nav class="frame__tags">
           <a href="#">#draggable tarps</a>
         </nav>
@@ -117,7 +118,7 @@
           <span id="info-tooltip" aria-label="Model information" tabindex="0" data-tooltip="This is not Jon Osmond">?</span>
         </p>
     </main>
-  
+
     <audio id="first-drop-audio" preload="auto">
       <source src="assets/first-drop.mp3" type="audio/mpeg" />
     </audio>

--- a/index.js
+++ b/index.js
@@ -21,9 +21,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestMessagesContainer = document.getElementById('suggest-messages');
   const suggestError = document.getElementById('suggest-error');
   const shuffleButton = document.getElementById('shuffle-button');
+  const clearSuggestionsButton = document.getElementById('clear-suggestions');
   const firstDropAudio = document.getElementById('first-drop-audio');
 
   const suitCheeseAudio = document.getElementById('suit-cheese-audio');
+  const SUGGEST_STORAGE_KEY = "shirtSuggestions";
 
   function playAudioExclusive(audioElement) {
     if (!audioElement) return;
@@ -160,6 +162,24 @@ document.addEventListener('DOMContentLoaded', () => {
   if (shuffleButton) {
     shuffleButton.addEventListener('click', () => {
       randomizeShirtPositions();
+    });
+  }
+
+  if (clearSuggestionsButton) {
+    clearSuggestionsButton.addEventListener('click', () => {
+      try {
+        localStorage.removeItem(SUGGEST_STORAGE_KEY);
+      } catch (err) {
+        if (isDev) {
+          console.warn('Failed to clear suggestions from storage', err);
+        }
+      }
+
+      if (suggestMessagesContainer) {
+        while (suggestMessagesContainer.firstChild) {
+          suggestMessagesContainer.removeChild(suggestMessagesContainer.firstChild);
+        }
+      }
     });
   }
 
@@ -674,7 +694,6 @@ document.addEventListener('DOMContentLoaded', () => {
   updateTooltip();
 
   // --- Suggestion Feature ---
-  const SUGGEST_STORAGE_KEY = 'shirtSuggestions';
 
   function loadSuggestions() {
     try {

--- a/test/ui.spec.js
+++ b/test/ui.spec.js
@@ -34,3 +34,16 @@ test('keyboard dragging moves shirt onto model', async ({ page }) => {
   await page.keyboard.press('Enter');
   await expect(center).toHaveAttribute('src', /mn-wild-jersey-model\.png$/);
 });
+
+test('clear suggestions button removes stored suggestions and messages', async ({ page }) => {
+  await page.evaluate(() => {
+    localStorage.setItem('shirtSuggestions', JSON.stringify([{ text: 'test', time: Date.now() }]));
+  });
+  await page.reload();
+  const msgSelector = '.suggest-marquee';
+  await expect(page.locator(msgSelector)).toHaveCount(1);
+  await page.click('#clear-suggestions');
+  const stored = await page.evaluate(() => localStorage.getItem('shirtSuggestions'));
+  expect(stored).toBeNull();
+  await expect(page.locator(msgSelector)).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add Clear suggestions button in the suggestion form
- implement clearing of localStorage and DOM messages in JS
- style the new button
- test the clearing behaviour via Playwright
- address review feedback (move constant, add aria label, cleanup whitespace)

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c791f70288324b22d593b0e87d2f8