### PR TITLE
Add close button to suggestion marquee

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -661,6 +661,16 @@ a:focus-visible {
     font-family: ui-monospace, monospace;
 }
 
+.suggest-close {
+    background: transparent;
+    border: none;
+    color: #000;
+    margin-left: 0.5rem;
+    font-size: 1rem;
+    cursor: pointer;
+    line-height: 1;
+}
+
 @keyframes suggest-scroll {
     from {
         transform: translateX(100%);

--- a/index.js
+++ b/index.js
@@ -728,8 +728,17 @@ document.addEventListener('DOMContentLoaded', () => {
       messageText.textContent = message || defaultMessage;
     }
 
+    const closeButton = document.createElement('button');
+    closeButton.className = 'suggest-close';
+    closeButton.setAttribute('aria-label', 'Close');
+    closeButton.textContent = '\u00D7';
+    closeButton.addEventListener('click', () => {
+      wrapper.remove();
+    });
+
 
     wrapper.appendChild(messageText);
+    wrapper.appendChild(closeButton);
     suggestMessagesContainer.appendChild(wrapper);
 
     wrapper.addEventListener('animationend', () => {


### PR DESCRIPTION
## Summary
- make suggestion notices dismissable
- style the new close button

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc0e971c0832481f6b99bc2e7afb1