### PR TITLE
Improve marquee suggestion close buttons

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -670,6 +670,12 @@ a:focus-visible {
     cursor: pointer;
     line-height: 1;
 }
+.suggest-close svg {
+    width: 1em;
+    height: 1em;
+    stroke: currentColor;
+    fill: none;
+}
 
 @keyframes suggest-scroll {
     from {

--- a/index.js
+++ b/index.js
@@ -731,7 +731,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const closeButton = document.createElement('button');
     closeButton.className = 'suggest-close';
     closeButton.setAttribute('aria-label', 'Close');
-    closeButton.textContent = '\u00D7';
+    closeButton.innerHTML =
+      '<svg class="close-icon" viewBox="0 0 16 16" aria-hidden="true">' +
+      '<path d="M4 4l8 8m0-8l-8 8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />' +
+      '</svg>';
     closeButton.addEventListener('click', () => {
       wrapper.remove();
     });


### PR DESCRIPTION
## Summary
- swap out plain text close icon for an inline SVG
- style `suggest-close` icon

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc23b5f608324aa698cd05cb6112c