### PR TITLE
Improve suggestion marquees

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -641,6 +641,10 @@ a:focus-visible {
     pointer-events: auto;
 }
 
+.suggest-marquee:hover {
+    animation-play-state: paused;
+}
+
 @media (prefers-reduced-motion: no-preference) {
     .suggest-marquee {
         animation: suggest-scroll 20s linear forwards;
@@ -659,6 +663,28 @@ a:focus-visible {
     padding: 0.5rem 1rem;
     border-radius: 6px;
     font-family: ui-monospace, monospace;
+}
+
+.suggest-close {
+    background: transparent;
+    border: none;
+    color: #555;
+    font-size: 1.1rem;
+    margin-left: 0.25rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    width: 1.5rem;
+    height: 1.5rem;
+    transition: background-color 0.2s ease;
+}
+
+.suggest-close:hover,
+.suggest-close:focus {
+    background-color: rgba(0, 0, 0, 0.1);
+    outline: none;
 }
 
 @keyframes suggest-scroll {

--- a/index.js
+++ b/index.js
@@ -729,12 +729,29 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
 
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'suggest-close';
+    closeBtn.type = 'button';
+    closeBtn.setAttribute('aria-label', 'Dismiss');
+    closeBtn.textContent = '×';
+
+    closeBtn.addEventListener('click', () => {
+      wrapper.remove();
+    });
+
     wrapper.appendChild(messageText);
+    wrapper.appendChild(closeBtn);
     suggestMessagesContainer.appendChild(wrapper);
 
     wrapper.addEventListener('animationend', () => {
       wrapper.remove();
     });
+
+    setTimeout(() => {
+      if (document.body.contains(wrapper)) {
+        wrapper.remove();
+      }
+    }, 20000);
   }
 
   // Show any previously saved suggestions when the page loads


### PR DESCRIPTION
## Summary
- add dismiss button and fallback timeout for suggestion marquees
- pause marquee animation on hover
- style close button

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccb458de4832492b25a41308ad066