### PR TITLE
Adjust marquee dismiss button

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -669,15 +669,15 @@ a:focus-visible {
     background: transparent;
     border: none;
     color: #555;
-    font-size: 1.1rem;
-    margin-left: 0.25rem;
+    font-size: 1.5rem;
+    margin-right: 0.25rem;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 2rem;
+    height: 2rem;
     transition: background-color 0.2s ease;
 }
 

--- a/index.js
+++ b/index.js
@@ -739,8 +739,8 @@ document.addEventListener('DOMContentLoaded', () => {
       wrapper.remove();
     });
 
-    wrapper.appendChild(messageText);
     wrapper.appendChild(closeBtn);
+    wrapper.appendChild(messageText);
     suggestMessagesContainer.appendChild(wrapper);
 
     wrapper.addEventListener('animationend', () => {


### PR DESCRIPTION
## Summary
- move suggestion close button before the text so it shows on the left
- enlarge the close button for better touch targets

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cce5f919483249d4d00b7fd779130