### PR TITLE
Add float-away effect for suggestion messages

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -641,6 +641,10 @@ a:focus-visible {
     pointer-events: auto;
 }
 
+.suggest-marquee.float-away {
+    pointer-events: none;
+}
+
 .suggest-marquee:hover {
     animation-play-state: paused;
 }
@@ -649,10 +653,18 @@ a:focus-visible {
     .suggest-marquee {
         animation: suggest-scroll 20s linear forwards;
     }
+
+    .suggest-marquee.float-away {
+        animation: suggest-float-away 0.7s ease forwards;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {
     .suggest-marquee {
+        animation: none;
+    }
+
+    .suggest-marquee.float-away {
         animation: none;
     }
 }
@@ -693,6 +705,17 @@ a:focus-visible {
     }
     to {
         transform: translateX(-100%);
+    }
+}
+
+@keyframes suggest-float-away {
+    from {
+        transform: translateY(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateY(-2rem);
+        opacity: 0;
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -743,8 +743,21 @@ document.addEventListener('DOMContentLoaded', () => {
     wrapper.appendChild(messageText);
     suggestMessagesContainer.appendChild(wrapper);
 
-    wrapper.addEventListener('animationend', () => {
-      wrapper.remove();
+    wrapper.addEventListener('mouseenter', () => {
+      const playState = getComputedStyle(wrapper).animationPlayState;
+      if (playState === 'paused') {
+        wrapper.classList.add('float-away');
+      }
+    });
+
+    wrapper.addEventListener('animationend', (e) => {
+      if (e.animationName === 'suggest-scroll') {
+        wrapper.classList.add('float-away');
+        return;
+      }
+      if (e.animationName === 'suggest-float-away') {
+        wrapper.remove();
+      }
     });
 
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- animate dismissed suggestion banners to float away
- allow manual dismissal of suggestions by hovering
- add float-away keyframes and motion-reduced fallbacks

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd1a844008324ba932b69eb038898