### PR TITLE
Improve responsive typography

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -5,7 +5,7 @@
 }
 
 :root {
-  font-size: 12px;
+  font-size: clamp(12px, 1.5vw, 16px);
 
   --color-text: #f2f2f2;      
 
@@ -348,7 +348,7 @@ a:focus-visible {
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    font-size: 11px;
+    font-size: 0.92rem;
     font-weight: bold;
     cursor: help;
     z-index: 15;
@@ -371,7 +371,7 @@ a:focus-visible {
     color: white;
     padding: 5px 10px;
     border-radius: 4px;
-    font-size: 12px;
+    font-size: 1rem;
     font-family: "Source Code Pro", monospace;
     white-space: nowrap;
     opacity: 0;


### PR DESCRIPTION
## Summary
- use `clamp()` for responsive root font-size
- convert tooltip font sizes to `rem`

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d71e98b088324b5dfe87c0095b7ea