### PR TITLE
Fix '#draggable tarps' link

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,12 @@
         </div>
       
         <nav class="frame__tags">
-          <a href="#">#draggable tarps</a>
+          <a
+            href="https://github.com/osmond/draggable-tarps"
+            target="_blank"
+            rel="noopener noreferrer"
+            >#draggable tarps</a
+          >
         </nav>
       </header>
       <div class="container">


### PR DESCRIPTION
## Summary
- link the "#draggable tarps" tag to the repository

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7862ade88324875e554f9440574e