### PR TITLE
Add dev favicon logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This project targets **Node.js 20**. Run `nvm use` to switch to this version.
 6. Optionally include another MP3 named `cheese.mp3` in the `assets/` directory.
    It will play whenever the suit shirt is placed on the model.
 
+7. When developing locally, the favicon switches to `assets/favicon-dev.svg`
+   so browser tabs are easily distinguished from production.
+
 
 All JavaScript is written in vanilla ES modules.
 

--- a/assets/favicon-dev.svg
+++ b/assets/favicon-dev.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff5f6d" />
+      <stop offset="100%" stop-color="#d7263d" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" fill="url(#grad)" />
+  <text x="64" y="86" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="72" font-weight="bold" fill="#ffffff">JO</text>
+</svg>

--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const suitCheeseAudio = document.getElementById('suit-cheese-audio');
 
+  const favicon = document.querySelector('link[rel="icon"]');
+  if (favicon && (isDev || window.location.hostname === 'localhost')) {
+    favicon.href = 'assets/favicon-dev.svg';
+  }
+
   function playAudioExclusive(audioElement) {
     if (!audioElement) return;
     const audios = [firstDropAudio, suitCheeseAudio];


### PR DESCRIPTION
## Summary
- create `favicon-dev.svg` with a red gradient
- swap favicon to dev version when running locally
- document how the dev favicon distinguishes local tabs

## Testing
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d80cea99c8324acba9e6f51beb905