### PR TITLE
Move shuffle button under shirts

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -483,7 +483,9 @@ a:focus-visible {
     font-family: inherit;
     transition: background-color 0.2s ease;
     text-decoration: none;
-    display: inline-flex;
+    display: block;
+    width: fit-content;
+    margin: 0 auto 1rem;
     align-items: center;
 }
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
           <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
       </button>
-        <button id="shuffle-button" type="button" aria-label="Shuffle shirt positions">Shuffle shirts</button>
       <div id="suggest-input-container" class="suggest-input-container">
         <input type="text" id="suggest-input" placeholder="Your shirt idea" />
         <button id="suggest-submit" aria-label="Submit">
@@ -133,6 +132,7 @@
           />
         </div>
       </div>
+        <button id="shuffle-button" type="button" aria-label="Shuffle shirt positions">Shuffle shirts</button>
         <p class="instructions">
           Drag a shirt onto the center image to try it on.
           <span id="info-tooltip" aria-label="Model information" tabindex="0" data-tooltip="This is not Jon Osmond">?</span>


### PR DESCRIPTION
## Summary
- relocate shuffle button under shirts
- center and space the shuffle button

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4eb3c048324b08899f4162c5591