### PR TITLE
Show suggestions in list

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -732,3 +732,21 @@ a:focus-visible {
     }
 }
 
+.suggest-list {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    max-height: 50vh;
+    overflow-y: auto;
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-family: ui-monospace, monospace;
+    font-size: 0.9rem;
+    z-index: 1005;
+}
+
+.suggest-item {
+    margin-bottom: 0.25rem;
+}
+

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       </div>
     </div>
     <div id="suggest-messages" class="suggest-messages" aria-live="polite"></div>
+    <div id="suggest-list" class="suggest-list"></div>
     <main>
       <header class="frame">
         <h1 class="frame__title">Jon Osmond</h1>

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestInput = document.getElementById('suggest-input');
   const suggestSubmit = document.getElementById('suggest-submit');
   const suggestMessagesContainer = document.getElementById('suggest-messages');
+  const suggestList = document.getElementById('suggest-list');
   const suggestError = document.getElementById('suggest-error');
   const shuffleButton = document.getElementById('shuffle-button');
   const firstDropAudio = document.getElementById('first-drop-audio');
@@ -797,15 +798,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 20000);
   }
 
+  function addSuggestionItem(text) {
+    if (!suggestList) return;
+    const item = document.createElement('div');
+    item.className = 'suggest-item';
+    item.textContent = text;
+    suggestList.appendChild(item);
+  }
+
   // Show any previously saved suggestions when the page loads
   loadSuggestions().forEach((s) => {
     if (s && s.text) {
-
       const msg =
         `Do you see ${escapeHtml(s.text)}? If not, send me an ` +
         '<a href="mailto:jonathan.osmond@gmail.com">email</a> and I\'ll be sure to add it!';
       displaySuggestion(s.text, msg, true);
-
+      addSuggestionItem(s.text);
     }
   });
 
@@ -818,6 +826,7 @@ document.addEventListener('DOMContentLoaded', () => {
           items.forEach((item) => {
             if (item && item.text) {
               displaySuggestion(item.text);
+              addSuggestionItem(item.text);
             }
           });
         }
@@ -874,6 +883,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (text) {
         displaySuggestion(text);
+        addSuggestionItem(text);
 
         const stored = loadSuggestions();
         stored.push({ text, time: Date.now() });


### PR DESCRIPTION
## Summary
- create fixed `suggest-list` container to collect suggestions
- add list item generation in the JS for saved, fetched, and new suggestions
- style suggestion list items

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb6241a008324b3bcea90dda28f88