### PR TITLE
Remove email prompt marquee

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Click the **Suggest a shirt** button in the top corner to share ideas for new de
 
 Suggestions are saved in your browser's local storage so they appear again the next
 time you visit the page. They are also posted to `/api/suggestions` and fetched
-on page load so everyone can see what other visitors have shared. When your
-suggestion reappears you'll see a message like "Do you see <your shirt idea>? If
-not, send me an [email](mailto:jonathan.osmond@gmail.com) and I'll be sure to
-add it!" prompting you to contact me if your idea hasn't been added yet.
+on page load so everyone can see what other visitors have shared.
+
+When you share an idea you'll see a message like "That's a great idea! I would
+love to see him wearing <your shirt idea>!"
 
 
 

--- a/index.js
+++ b/index.js
@@ -809,10 +809,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // Show any previously saved suggestions when the page loads
   loadSuggestions().forEach((s) => {
     if (s && s.text) {
-      const msg =
-        `Do you see ${escapeHtml(s.text)}? If not, send me an ` +
-        '<a href="mailto:jonathan.osmond@gmail.com">email</a> and I\'ll be sure to add it!';
-      displaySuggestion(s.text, msg, true);
       addSuggestionItem(s.text);
     }
   });


### PR DESCRIPTION
## Summary
- stop showing an email marquee for saved suggestions
- adjust README to explain the new behavior

## Testing
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebe87e8308324bd92493772d52e0c