### PR TITLE
Implement draggable suggestion message container

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -634,9 +634,15 @@ a:focus-visible {
     left: 0;
     right: 0;
     overflow: visible;
-    pointer-events: none;
+    pointer-events: auto;
     z-index: 1010;
     text-align: center;
+    cursor: grab;
+    min-height: 1rem;
+}
+
+.suggest-messages.dragging {
+    cursor: grabbing;
 }
 
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const suggestSubmit = document.getElementById('suggest-submit');
   const suggestMessagesContainer = document.getElementById('suggest-messages');
   const suggestList = document.getElementById('suggest-list');
+  if (suggestMessagesContainer) {
+    makeContainerDraggable(suggestMessagesContainer);
+  }
   const suggestError = document.getElementById('suggest-error');
   const shuffleButton = document.getElementById('shuffle-button');
   const firstDropAudio = document.getElementById('first-drop-audio');
@@ -729,6 +732,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.addEventListener('mouseup', onEnd);
       document.addEventListener('touchend', onEnd);
       ev.preventDefault();
+      ev.stopPropagation();
     }
     function onMove(ev) {
       const pt = ev.touches ? ev.touches[0] : ev;
@@ -747,6 +751,38 @@ document.addEventListener('DOMContentLoaded', () => {
     el.addEventListener('mousedown', onStart);
     el.addEventListener('touchstart', onStart, { passive: false });
     el.style.cursor = 'grab';
+  }
+
+  function makeContainerDraggable(el) {
+    let offsetX = 0;
+    let offsetY = 0;
+    function onStart(ev) {
+      const pt = ev.touches ? ev.touches[0] : ev;
+      const rect = el.getBoundingClientRect();
+      offsetX = pt.clientX - rect.left;
+      offsetY = pt.clientY - rect.top;
+      el.classList.add('dragging');
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('touchmove', onMove, { passive: false });
+      document.addEventListener('mouseup', onEnd);
+      document.addEventListener('touchend', onEnd);
+      ev.preventDefault();
+    }
+    function onMove(ev) {
+      const pt = ev.touches ? ev.touches[0] : ev;
+      el.style.left = `${pt.clientX - offsetX}px`;
+      el.style.top = `${pt.clientY - offsetY}px`;
+      ev.preventDefault();
+    }
+    function onEnd() {
+      el.classList.remove('dragging');
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('touchmove', onMove);
+      document.removeEventListener('mouseup', onEnd);
+      document.removeEventListener('touchend', onEnd);
+    }
+    el.addEventListener('mousedown', onStart);
+    el.addEventListener('touchstart', onStart, { passive: false });
   }
 
   function displaySuggestion(text, message, allowHTML = false) {


### PR DESCRIPTION
## Summary
- make `.suggest-messages` container draggable
- expose drag cursor styles for the container

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebfad39148324b5fc72de04bc59a1