### PR TITLE
Randomize suggestion list location

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -739,9 +739,9 @@ a:focus-visible {
 }
 
 .suggest-list {
-    position: fixed;
-    bottom: 1rem;
-    right: 1rem;
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
     max-height: 50vh;
     overflow-y: auto;
     background-color: rgba(255, 255, 255, 0.9);

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     makeContainerDraggable(suggestMessagesContainer);
   }
   if (suggestList) {
+    randomizeSuggestListPosition();
     makeContainerDraggable(suggestList);
   }
   const suggestError = document.getElementById('suggest-error');
@@ -160,6 +161,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
       placed.push(shirt.getBoundingClientRect());
     });
+  }
+
+  function randomizeSuggestListPosition() {
+    if (!suggestList) return;
+    const rect = suggestList.getBoundingClientRect();
+    const maxLeft = window.innerWidth - rect.width;
+    const maxTop = window.innerHeight - rect.height;
+    const left = Math.random() * maxLeft;
+    const top = Math.random() * maxTop;
+    suggestList.style.left = `${left}px`;
+    suggestList.style.top = `${top}px`;
+    suggestList.style.right = 'auto';
+    suggestList.style.bottom = 'auto';
   }
 
   preloadImages(uniqueImagePaths, () => {


### PR DESCRIPTION
## Summary
- position suggestion list absolutely by default
- randomize suggestion list coordinates on page load

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2c1dc388324a59d8a3c08d4881c