### PR TITLE
Disable gradient animation on mobile

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -49,6 +49,13 @@ body {
   }
 }
 
+@media (max-width: 767px) {
+  body {
+    background: var(--color-bg);
+    animation: none;
+  }
+}
+
 @media (scripting: enabled) {
   .loading::before,
   .loading::after {


### PR DESCRIPTION
## Summary
- stop gradient background animation on small screens

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5395cbc8324b6503c0bec33b0ab