### PR TITLE
Implement suggestion removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Suggestions are saved in your browser's local storage so they appear again the n
 time you visit the page. They are also posted to `/api/suggestions` and fetched
 on page load so everyone can see what other visitors have shared.
 
+Each item in the **Shirt Suggestions** list now includes a small `×` button.
+Click it to remove that suggestion from the list. This deletes it from your
+local storage and also issues a request to the server so it disappears for
+everyone.
+
 When you share an idea you'll see a message like "That's a great idea! I would
 love to see him wearing <your shirt idea>!"
 

--- a/css/base.css
+++ b/css/base.css
@@ -774,5 +774,29 @@ a:focus-visible {
 .suggest-item {
     margin-bottom: 0.25rem;
     color: #000;
+    display: flex;
+    align-items: center;
+}
+
+.suggest-delete {
+    background: transparent;
+    border: none;
+    color: #555;
+    font-size: 1rem;
+    margin-left: 0.25rem;
+    cursor: pointer;
+    border-radius: 50%;
+    width: 1.25rem;
+    height: 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease;
+}
+
+.suggest-delete:hover,
+.suggest-delete:focus {
+    background-color: rgba(0, 0, 0, 0.1);
+    outline: none;
 }
 


### PR DESCRIPTION
## Summary
- add delete button next to each suggestion
- remove suggestion from local storage and server
- expose DELETE /api/suggestions endpoint
- document new deletion capability

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec59b60b48324ada9e1c40723800d