### PR TITLE
Update prefer-reduced-motion for suggest marquee

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -660,16 +660,11 @@ a:focus-visible {
     position: relative;
     pointer-events: auto;
     touch-action: none;
+    animation: suggest-scroll 20s linear forwards;
 }
 
 .suggest-marquee:hover {
     animation-play-state: paused;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .suggest-marquee {
-        animation: suggest-scroll 20s linear forwards;
-    }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- disable animation on `.suggest-marquee` when `prefers-reduced-motion` is enabled

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed6b2bce88324af55703fc5bd0b37