### PR TITLE
Fix path traversal in server

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,11 +24,26 @@ function getContentType(filePath) {
 }
 
 const server = createServer(async (req, res) => {
-  const { pathname } = parse(req.url, true);
+  let { pathname } = parse(req.url, true);
 
-  // No API endpoints are currently provided; serve static files only
+  // Normalize and sanitize the requested path
+  pathname = path.normalize(decodeURIComponent(pathname));
 
+  // Strip any leading ".." segments or reject absolute paths
+  if (pathname.startsWith('..') || path.isAbsolute(pathname)) {
+    res.writeHead(400);
+    res.end('Bad Request');
+    return;
+  }
+
+  // Construct the full file path
   let filePath = path.join(__dirname, pathname);
+  if (!filePath.startsWith(__dirname)) {
+    res.writeHead(404);
+    res.end('Not Found');
+    return;
+  }
+
   if (pathname === '/' || !path.extname(pathname)) {
     filePath = path.join(__dirname, pathname === '/' ? 'index.html' : `${pathname}.html`);
   }


### PR DESCRIPTION
## Summary
- normalize and validate `pathname`
- return 400 for absolute or `..` segments
- ensure resolved paths stay inside server directory

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed8b24e408324ab81cdf368b615d1