### PR TITLE
Update README for local storage and static server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ This project targets **Node.js 20**. Run `nvm use` to switch to this version.
    Node.js and npm for offline use).
 2. Install the browsers needed for Playwright tests with `npx playwright install`.
 3. Run the test suite with `npm test`.
-4. Launch the site with `npm start`. This starts the `server.js` script which
-   serves the site and saves shirt suggestions to `suggestions.json` on
-   [http://localhost:3000](http://localhost:3000). Open the served
-   `index.html` in your browser.
+4. Launch the site with `npm start`. This starts the `server.js` script which only serves static files on [http://localhost:3000](http://localhost:3000). Open the served `index.html` in your browser.
 5. Optionally add a sound effect by placing an MP3 named `first-drop.mp3` in the
    `assets/` directory. It will play the first time a shirt is placed on the
    model during a session.
@@ -43,18 +40,13 @@ over the center image, try it on.
 
 ## Suggesting Shirts
 
-Click the **Suggest a shirt** button in the top corner to share ideas for new designs.
-
-
-
+Click the **Suggest a shirt** button in the top corner to share ideas for new designs. Shirt ideas are stored in your browser's localStorage and sent to Firebase so they appear for everyone.
 Each item in the **Shirt Suggestions** list now includes a small `×` button.
 Click it to remove that suggestion from the list. This deletes it from your
 local storage and also removes it from the shared list for everyone.
 
 When you share an idea you'll see a message like "That's a great idea! I would
 love to see him wearing <your shirt idea>!"
-
-
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify that `server.js` simply serves static files
- remove the `suggestions.json` reference
- explain that suggestions persist in localStorage and sync to Firebase

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed8aad1908324be62922bca072e09