### PR TITLE
Move Firebase config to env-driven module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,31 @@ This project targets **Node.js 20**. Run `nvm use` to switch to this version.
    Node.js and npm for offline use).
 2. Install the browsers needed for Playwright tests with `npx playwright install`.
 3. Run the test suite with `npm test`.
-4. Launch the site with `npm start`. This starts the `server.js` script which
+4. Before launching the site, set the Firebase environment variables used by
+   `config.js`:
+
+   ```sh
+   export FIREBASE_API_KEY=your-key
+   export FIREBASE_AUTH_DOMAIN=your-domain
+   export FIREBASE_DATABASE_URL=your-db-url
+   export FIREBASE_PROJECT_ID=your-project
+   export FIREBASE_STORAGE_BUCKET=your-bucket
+   export FIREBASE_MESSAGING_SENDER_ID=your-sender-id
+   export FIREBASE_APP_ID=your-app-id
+   export FIREBASE_MEASUREMENT_ID=your-measurement-id
+   ```
+
+   These variables are read at runtime when `config.js` is served.
+5. Launch the site with `npm start`. This starts the `server.js` script which
    serves the site and saves shirt suggestions to `suggestions.json` on
    [http://localhost:3000](http://localhost:3000). Open the served
    `index.html` in your browser.
-5. Optionally add a sound effect by placing an MP3 named `first-drop.mp3` in the
+6. Optionally add a sound effect by placing an MP3 named `first-drop.mp3` in the
    `assets/` directory. It will play the first time a shirt is placed on the
    model during a session.
-
-6. Optionally include another MP3 named `cheese.mp3` in the `assets/` directory.
+7. Optionally include another MP3 named `cheese.mp3` in the `assets/` directory.
    It will play whenever the suit shirt is placed on the model.
-
-
-7. During local development (running on `localhost`, `127.0.0.1`, or when
+8. During local development (running on `localhost`, `127.0.0.1`, or when
    `NODE_ENV` is not `production`), the favicon switches to
    `assets/favicon-dev.svg` so browser tabs are easily distinguished from
    production.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,12 @@
+export const firebaseConfig = {
+  apiKey: process.env.FIREBASE_API_KEY || '',
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN || '',
+  databaseURL: process.env.FIREBASE_DATABASE_URL || '',
+  projectId: process.env.FIREBASE_PROJECT_ID || '',
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET || '',
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID || '',
+  appId: process.env.FIREBASE_APP_ID || '',
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID || '',
+};
+
+export default firebaseConfig;

--- a/index.html
+++ b/index.html
@@ -153,19 +153,7 @@
 
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-database-compat.js"></script>
-    <script>
-      const firebaseConfig = {
-        apiKey: "AIzaSyD756akcbfFofdD0RWHDUx9y9-u_lWanIA4",
-        authDomain: "draggable-tarps.firebaseapp.com",
-        databaseURL: "https://draggable-tarps-default-rtdb.firebaseio.com/",
-        projectId: "draggable-tarps",
-        storageBucket: "draggable-tarps.appspot.com",
-        messagingSenderId: "271867687042",
-        appId: "1:271867687042:web:a6a559f20ffefdc893c49b",
-        measurementId: "G-JTFVKWHF30",
-      };
-      firebase.initializeApp(firebaseConfig);
-    </script>
+    <script type="module" src="config.js"></script>
     <script type="module" src="index.js"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { parse } from 'url';
+import { firebaseConfig } from './config.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -25,6 +26,16 @@ function getContentType(filePath) {
 
 const server = createServer(async (req, res) => {
   const { pathname } = parse(req.url, true);
+
+  if (pathname === '/config.js') {
+    const js = `export const firebaseConfig = ${JSON.stringify(firebaseConfig)};\n` +
+      `if (typeof window !== 'undefined' && window.firebase) {\n` +
+      `  window.firebase.initializeApp(firebaseConfig);\n` +
+      `}`;
+    res.writeHead(200, { 'Content-Type': 'text/javascript' });
+    res.end(js);
+    return;
+  }
 
   // No API endpoints are currently provided; serve static files only
 


### PR DESCRIPTION
## Summary
- pull firebase config values from environment variables via `config.js`
- serve firebase config from `server.js`
- load `config.js` from `index.html`
- document environment variables in README

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed8b9eaf48324981809cb12efe3e0