### PR TITLE
Add Google fonts and responsive typography

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -18,11 +18,54 @@
 
 body {
   margin: 0;
-  color: var(--color-text);
+  color: #111;
   background: var(--color-bg);
-  font-family: ui-monospace, monospace;
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+nav,
+.mono,
+.code {
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+h2 {
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+p,
+li {
+  font-size: 1rem;
+  font-weight: 400;
+}
+
+.uppercase {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+a,
+button {
+  transition: all 0.2s ease;
+}
+
+a:hover,
+button:hover {
+  font-weight: 600;
+  letter-spacing: 0.03em;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -250,7 +293,7 @@ a:focus-visible {
 
 .instructions {
     margin: 1rem 0;
-    font-family: ui-monospace, monospace;
+    font-family: 'Inter', sans-serif;
     text-align: center;
     color: #333;
     position: relative;
@@ -363,7 +406,7 @@ a:focus-visible {
     cursor: help;
     z-index: 15;
     transition: border-color 0.2s ease, color 0.2s ease;
-    font-family: sans-serif;
+    font-family: 'IBM Plex Mono', monospace;
 }
 
 #info-tooltip:hover {
@@ -382,7 +425,7 @@ a:focus-visible {
     padding: 5px 10px;
     border-radius: 4px;
     font-size: 1rem;
-    font-family: "Source Code Pro", monospace;
+    font-family: 'IBM Plex Mono', monospace;
     white-space: nowrap;
     opacity: 0;
     visibility: hidden;
@@ -447,7 +490,7 @@ a:focus-visible {
     z-index: 1010;
     text-align: right;
     color: #000;
-    font-family: ui-monospace, monospace;
+    font-family: 'Inter', sans-serif;
 }
 
 @media (max-width: 767px) {
@@ -458,7 +501,7 @@ a:focus-visible {
         z-index: 1010;
         text-align: unset;
         color: #000;
-        font-family: ui-monospace, monospace;
+        font-family: 'Inter', sans-serif;
     }
 
     .suggest-input-container {
@@ -678,7 +721,7 @@ a:focus-visible {
     color: #000;
     padding: 0.5rem 1rem;
     border-radius: 6px;
-    font-family: ui-monospace, monospace;
+    font-family: 'Inter', sans-serif;
 }
 
 .suggest-close {
@@ -749,7 +792,7 @@ a:focus-visible {
     background-color: rgba(255, 255, 255, 0.9);
     padding: 0.5rem 1rem;
     border-radius: 6px;
-    font-family: ui-monospace, monospace;
+    font-family: 'Inter', sans-serif;
     font-size: 0.9rem;
     cursor: grab;
     z-index: 1005;
@@ -793,5 +836,31 @@ a:focus-visible {
 .suggest-delete:focus {
     background-color: rgba(0, 0, 0, 0.1);
     outline: none;
+}
+
+@media (max-width: 600px) {
+  h1 {
+    font-size: 1.5rem;
+  }
+
+  p {
+    font-size: 0.95rem;
+  }
+}
+
+.font-mono {
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.font-sans {
+  font-family: 'Inter', sans-serif;
+}
+
+.text-lg {
+  font-size: 1.25rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <title>Jon Osmond</title>
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="css/base.css" />
     <script>
       document.documentElement.className = 'js';


### PR DESCRIPTION
## Summary
- load Inter and IBM Plex Mono from Google Fonts
- use Inter globally and IBM Plex Mono for headings and code
- define basic type scale and utility classes
- improve readability with letter spacing, hover effects and responsive sizes

## Testing
- `npm test` *(fails: serves content type, static server, UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_684ee6a21e208324bd0f5a7828cdde16