### PR TITLE
Add minimalist button style example

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -550,6 +550,30 @@ a:focus-visible {
     background-color: var(--color-link-hover);
 }
 
+.minimal-btn {
+    background-color: transparent;
+    border: 1px solid #333;
+    color: #333;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.5rem 1rem;
+    font-family: inherit;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.minimal-btn:hover,
+.minimal-btn:focus {
+    background-color: #333;
+    color: #fff;
+}
+
+.minimal-btn:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.4);
+}
+
 #suggest-link .toggle-icon {
     width: 1em;
     height: 1em;

--- a/index.html
+++ b/index.html
@@ -141,7 +141,8 @@
           <span id="info-tooltip" aria-label="Model information" tabindex="0" data-tooltip="This is not Jon Osmond">?</span>
         </p>
         <button id="shuffle-button" type="button" aria-label="Shuffle shirt positions">Shuffle shirts</button>
-    </main>
+        <button class="minimal-btn" type="button">Minimal button</button>
+      </main>
   
     <audio id="first-drop-audio" preload="auto">
       <source src="assets/first-drop.mp3" type="audio/mpeg" />


### PR DESCRIPTION
## Summary
- add Minimal button example to HTML
- define `.minimal-btn` styles with subtle border and color inversion on hover

## Testing
- `npm test` *(fails: 3 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684eefa32fc08324bdb7fd71e68dcb15