### PR TITLE
Add center-growing underline hover effect

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -164,26 +164,24 @@ a {
   outline: none;
   cursor: pointer;
   position: relative;
-  overflow: hidden;
+  padding-bottom: 2px;
 }
 
-/* Sliding highlight effect */
-a::before {
+a::after {
   content: "";
   position: absolute;
-  inset: 0;
-  background: var(--color-link-hover);
-  transform: translateX(-100%);
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  transform: scaleX(0);
+  transform-origin: center;
   transition: transform 0.3s ease;
-  z-index: -1;
 }
 
-a:hover {
-  color: #fff;
-}
-
-a:hover::before {
-  transform: translateX(0);
+a:hover::after {
+  transform: scaleX(1);
 }
 
 a:focus {


### PR DESCRIPTION
## Summary
- style `a` elements with a center-growing underline animation

## Testing
- `npm test` *(fails: playwright tests did not pass)*

------
https://chatgpt.com/codex/tasks/task_e_684eefb95b3c832488e7887ee8c3e95b